### PR TITLE
Dockerized outlier-detect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7.12-buster
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY . /usr/local/outlier
+
+WORKDIR /usr/local/outlier
+RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ COPY . /usr/local/outlier
 
 WORKDIR /usr/local/outlier
 RUN python3 setup.py install
+
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The primary input for the algorithm is a csv file containing survey responses, f
 
 The distribution of answers from Interviewer 1 are compared to the distribution of answers from both Interviewers 2 & 3. Likewise for Interviewer 2 with the answers of 1 & 3 and for Interviewer 3 with 1 & 2.
 
-## Usage
+## Installation
+
+### Native
 
 1. Once you've downloaded or cloned this repository, you need to first make sure the necessary libararies are installed on your machine. We recommend you do this by running the following command:
 
@@ -43,6 +45,18 @@ Optionally, the library is also available to be installed globally, using the fo
 ```bash
 python3 setup.py install
 ```
+
+### Docker image
+
+Optionally pull https://hub.docker.com/repository/docker/arongizra/outlier-detect/general
+ahead of the first execution..
+
+Execute a calculation:
+```bash
+docker run -v $PWD:/src arongizra/outlier-detect:0.1 python example.py
+```
+
+## Usage
 
 2. Once the proper libraries have been installed, open the repository on your code editor of choice.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ matplotlib==3.3.4
 numpy==1.19.5
 pandas==1.1.5
 scikit-learn==0.24.2
-scipy
+scipy==1.5.4
 seaborn==0.11.1
 simple-settings==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ matplotlib==3.3.4
 numpy==1.19.5
 pandas==1.1.5
 scikit-learn==0.24.2
-scipy==1.5.4
+scipy
 seaborn==0.11.1
 simple-settings==1.0.0


### PR DESCRIPTION
For instance it was not possible (or too hard) to install the library on Fedora 35.

![image](https://user-images.githubusercontent.com/114076/144008735-88dd3a85-e2cc-46fa-bcd3-1a707c370b4c.png)
