### PR TITLE
Optimized outlier detection runtime

### DIFF
--- a/outlierdetect/benchmark_outlierdetect.py
+++ b/outlierdetect/benchmark_outlierdetect.py
@@ -17,12 +17,25 @@ import timeit
 from line_profiler import profile
 import outlierdetect
 
-def prepare_dataset():
+def prepare_dataset(agg_unit_scale=0.01, num_attr=3):
     """Prepares dataset for outlier detection algo benchmarking.
-    Sets variables as global for easy use of benchmarking/profiling.    
-    Args:
-        None
+    Sets variables as global for easy use of benchmarking/profiling.
 
+    Benchmark dataset is scikit-learn's Adult Census Income Dataset hosted by Hugging Face and
+    originally retrieved from the UCI machine learning repository. It contains ~32.6k rows of
+    anonymized income information and related factors from the 1994 Census Bureau database.
+    For the pruposes of benchmarking the outlier detection algorithm, we simulate the outlier
+    detection of worker surveys by randomly assigning an aggregation unit between 0 and
+    agg_unit_scale*len(data), meant to represent a worker id. The outlier detection is run on
+    the "education", "occupation" and "marital.status" fields of the dataset which are
+    categorical variables containing 16, 15 and 7 unique values, respectively.
+
+
+    Args:
+        agg_unit_scale (float): Constant multiplier for aggregation unit in outlier detection.
+            For example, if dataset length 10,000 and agg_unit_scale=0.01, the number of agg units
+            (e.g. workers) is 100. Must be between 0 and 1.
+        num_attr (int): Number of survey questions to use in benchmarking. Must be in [1,2,3].
     Returns:
         None
     """
@@ -32,9 +45,9 @@ def prepare_dataset():
     data = load_dataset("scikit-learn/adult-census-income")
     data = data['train'].to_pandas()
     agg_col = 'worker_id'
-    #Add a worker id column
-    data[agg_col] = np.random.randint(round(len(data)/100), size=len(data))
-    attributes = ['education', 'occupation', 'marital.status']
+    #Add a worker id column (agg unit)
+    data[agg_col] = np.random.randint(round(len(data)*agg_unit_scale), size=len(data))
+    attributes = ['education', 'occupation', 'marital.status'][:num_attr]
     return None
 
 @profile
@@ -49,8 +62,43 @@ def run_sample_mma():
     outlierdetect.run_mma(data, agg_col, attributes)
     return None
 
+def run_line_profiler():
+    prepare_dataset()
+    run_sample_mma()
+    return None
+
+
+def run_benchmark():
+    """
+    Prints execution time for running outlier detection algorithm on dataset and observes
+    changes in runtime for different values of number of aggregation units (e.g. number of
+    workers) and number of fields/questions. Execution time is measured as the minimum of 5
+    runs, with each run executing the outlier detection algorithm 4 times.
+
+    Args:
+        None
+    Returns:
+        None
+
+    """
+    print('Benchmarking outlier detection algorithm')
+    
+    print('')
+    print('Observing impact of aggregation unit scale')
+    for agg_unit_scale in [0.01, 0.02, 0.03]:
+        min_runtime = min(timeit.repeat("run_sample_mma()", setup="prepare_dataset(agg_unit_scale={})".format(agg_unit_scale), globals=globals(), number=4))
+        formatted_time = "{:.2f}".format(min_runtime)
+        print(f"    Aggregation unit scale = {agg_unit_scale}, Execution time: {formatted_time} seconds")
+    
+    print('')
+    print('Observing impact of number of questions')
+    for num_attr in [1,2,3]:
+        min_runtime = min(timeit.repeat("run_sample_mma()", setup="prepare_dataset(num_attr={})".format(num_attr), globals=globals(), number=4))
+        formatted_time = "{:.2f}".format(min_runtime)
+        print(f"    Number of questions = {num_attr}, Execution time: {formatted_time} seconds")
+    return None   
+
 
 if __name__ == '__main__':
-    min_runtime = min(timeit.repeat("run_sample_mma()", setup="prepare_dataset()", globals=globals(), number=4))
-    formatted_time = "{:.2f}".format(min_runtime)
-    print(f"Execution time: {formatted_time} seconds")
+    run_benchmark()
+    #run_line_profiler()

--- a/outlierdetect/benchmark_outlierdetect.py
+++ b/outlierdetect/benchmark_outlierdetect.py
@@ -1,0 +1,56 @@
+"""
+benchmark_outlierdetect.py
+
+Created by Anna Dixon on 2023-10-25.
+
+Benchmark script for outlierdetect.py.  To run:
+
+python benchmark_outlierdetect.py
+
+"""
+
+import timeit
+import pandas as pd
+import numpy as np
+from datasets import load_dataset
+import timeit
+from line_profiler import profile
+import outlierdetect
+
+def prepare_dataset():
+    """Prepares dataset for outlier detection algo benchmarking.
+    Sets variables as global for easy use of benchmarking/profiling.    
+    Args:
+        None
+
+    Returns:
+        None
+    """
+    global data
+    global agg_col
+    global attributes
+    data = load_dataset("scikit-learn/adult-census-income")
+    data = data['train'].to_pandas()
+    agg_col = 'worker_id'
+    #Add a worker id column
+    data[agg_col] = np.random.randint(round(len(data)/100), size=len(data))
+    attributes = ['education', 'occupation', 'marital.status']
+    return None
+
+@profile
+def run_sample_mma():
+    """
+    Runs MMA algorithm for benchmarking dataset.
+    Args:
+        None
+    Returns:
+        None
+    """
+    outlierdetect.run_mma(data, agg_col, attributes)
+    return None
+
+
+if __name__ == '__main__':
+    min_runtime = min(timeit.repeat("run_sample_mma()", setup="prepare_dataset()", globals=globals(), number=4))
+    formatted_time = "{:.2f}".format(min_runtime)
+    print(f"Execution time: {formatted_time} seconds")

--- a/outlierdetect/benchmark_outlierdetect.py
+++ b/outlierdetect/benchmark_outlierdetect.py
@@ -14,7 +14,6 @@ import pandas as pd
 import numpy as np
 from datasets import load_dataset
 import timeit
-from line_profiler import profile
 import outlierdetect
 
 def prepare_dataset(agg_unit_scale=0.01, num_attr=3):
@@ -50,7 +49,6 @@ def prepare_dataset(agg_unit_scale=0.01, num_attr=3):
     attributes = ['education', 'occupation', 'marital.status'][:num_attr]
     return None
 
-@profile
 def run_sample_mma():
     """
     Runs MMA algorithm for benchmarking dataset.
@@ -60,11 +58,6 @@ def run_sample_mma():
         None
     """
     outlierdetect.run_mma(data, agg_col, attributes)
-    return None
-
-def run_line_profiler():
-    prepare_dataset()
-    run_sample_mma()
     return None
 
 
@@ -101,4 +94,3 @@ def run_benchmark():
 
 if __name__ == '__main__':
     run_benchmark()
-    #run_line_profiler()

--- a/outlierdetect/outlierdetect.py
+++ b/outlierdetect/outlierdetect.py
@@ -68,7 +68,6 @@ import collections
 import itertools
 import numpy as np
 import sys
-from line_profiler import profile
 
 # Import optional dependencies
 _PANDAS_AVAILABLE = False
@@ -98,7 +97,6 @@ if _STATS_AVAILABLE:
     class MultinomialModel:
         """Model implementing MMA.  Requries scipy module."""
 
-        @profile
         def compute_outlier_scores(self, frequencies):
             """Computes the SVA outlier scores fo the given frequencies dictionary.
 
@@ -136,7 +134,6 @@ if _STATS_AVAILABLE:
                     p_values[agg_unit] = p_value
             return outlier_scores, expected_frequencies, p_values
 
-        @profile
         def _compute_x2_statistic(self, expected, actual):
             """Computes the X^2 statistic for observed frequencies.
             Args:
@@ -160,7 +157,6 @@ if _STATS_AVAILABLE:
                                 df=len(rng))
             return chi_squared_stat, p_value
 
-        @profile
         def _sum_frequencies(self, rng, frequencies):
             """Sums frequencies for each aggregation unit.
             
@@ -253,7 +249,6 @@ class SValueModel:
 
 
 ########################################## Helper functions ########################################
-@profile
 def _normalize_counts(counts, val=1):
     """Normalizes a dictionary of counts, such as those returned by _get_frequencies().
 
@@ -271,7 +266,6 @@ def _normalize_counts(counts, val=1):
         frequencies[r] = val * float(counts[r]) / float(n)
     return frequencies
 
-@profile
 def _get_frequencies(data, col, col_vals, agg_col, agg_unit, agg_to_data):
     """Computes a frequencies dictionary for a given column and aggregation unit.
     
@@ -298,7 +292,6 @@ def _get_frequencies(data, col, col_vals, agg_col, agg_unit, agg_to_data):
             frequencies[name] = frequencies[name] + 1
     return frequencies, interesting_data
 
-@profile
 def _run_alg(data, agg_col, cat_cols, model, null_responses):
     """Runs an outlier detection algorithm, taking the model to use as input.
     
@@ -350,7 +343,6 @@ def _run_alg(data, agg_col, cat_cols, model, null_responses):
 ########################################## Public functions ########################################
 
 if _STATS_AVAILABLE:
-    @profile
     def run_mma(data, aggregation_column, categorical_columns, null_responses=[]):
         """Runs the MMA algorithm (requires scipy module).
         

--- a/outlierdetect/outlierdetect.py
+++ b/outlierdetect/outlierdetect.py
@@ -68,6 +68,7 @@ import collections
 import itertools
 import numpy as np
 import sys
+from line_profiler import profile
 
 # Import optional dependencies
 _PANDAS_AVAILABLE = False
@@ -97,6 +98,7 @@ if _STATS_AVAILABLE:
     class MultinomialModel:
         """Model implementing MMA.  Requries scipy module."""
 
+        @profile
         def compute_outlier_scores(self, frequencies):
             """Computes the SVA outlier scores fo the given frequencies dictionary.
 
@@ -106,7 +108,7 @@ if _STATS_AVAILABLE:
 
             Returns:
                 - dictionary mapping (aggregation unit) -> (MMA outlier score for aggregation unit).
-                - dictionary mapping (aggregation unit) ->  return from _sum_frequencies: (a dictionary mapping (value) -> (number of times all aggregation units apart from agg_unit reported this value)).
+                - dictionary mapping (aggregation unit) -> (number of times all aggregation units apart from agg_unit reported this value).
                 - dictionary mapping (aggregation unit) -> (P value for aggregation unit).
             """
             if len(frequencies.keys()) < 2:
@@ -115,15 +117,18 @@ if _STATS_AVAILABLE:
             outlier_scores = {}
             expected_frequencies = {}
             p_values = {}
+            #Find the total sums for all agg units
+            summed_freq = self._sum_frequencies(rng, frequencies)
             for agg_unit in list(frequencies.keys()):
-                summed_freq = self._sum_frequencies(agg_unit, frequencies)
-                expected_frequencies[agg_unit] = summed_freq
-                if(sum(summed_freq.values()) == 0):
+                expected_frequencies[agg_unit] = summed_freq.copy()
+                for r in rng:
+                    expected_frequencies[agg_unit][r] -= frequencies[agg_unit][r]
+                if(sum(expected_frequencies[agg_unit].values()) == 0):
                     outlier_scores[agg_unit] = 0
                     p_values[agg_unit] = 1
                 else:
                     expected_counts = _normalize_counts(
-                        summed_freq,
+                        expected_frequencies[agg_unit],
                         val=sum([frequencies[agg_unit][r] for r in rng]))
                     x2, p_value = self._compute_x2_statistic(expected_counts, frequencies[agg_unit])
                     # logsf gives the log of the survival function (1 - cdf).
@@ -131,7 +136,7 @@ if _STATS_AVAILABLE:
                     p_values[agg_unit] = p_value
             return outlier_scores, expected_frequencies, p_values
 
-
+        @profile
         def _compute_x2_statistic(self, expected, actual):
             """Computes the X^2 statistic for observed frequencies.
             Args:
@@ -155,11 +160,12 @@ if _STATS_AVAILABLE:
                                 df=len(rng))
             return chi_squared_stat, p_value
 
-        def _sum_frequencies(self, agg_unit, frequencies):
-            """Sums frequencies for each aggregation unit except the given one.
+        @profile
+        def _sum_frequencies(self, rng, frequencies):
+            """Sums frequencies for each aggregation unit.
             
             Args:
-                agg_unit: the aggregation unit of concern.
+                rng: all possible values to count.
                 frequencies: dictionary of dictionaries, mapping (aggregation unit) -> (value) ->
                     (number of times aggregation unit reported value).
             
@@ -168,18 +174,14 @@ if _STATS_AVAILABLE:
                 agg_unit reported this value)
 
             """
-            # Get the range from the frequencies dictionary.  Assumes that the range is the same
-            # for each aggregation unit in this distribution.  Bad things may happen if this is not
-            # the case.
-            rng = frequencies[agg_unit].keys()
+            # Assumes that the range is the same for each aggregation unit in this distribution.
+            # Bad things may happen if this is not the case.
             all_frequencies = {}
             for r in rng:
                 all_frequencies[r] = 0
-            for other_agg_unit in list(frequencies.keys()):
-                if other_agg_unit == agg_unit:
-                    continue
+            for agg_unit in list(frequencies.keys()):
                 for r in rng:
-                    all_frequencies[r] += frequencies[other_agg_unit][r]        
+                    all_frequencies[r] += frequencies[agg_unit][r]        
             return all_frequencies
 
 
@@ -251,7 +253,7 @@ class SValueModel:
 
 
 ########################################## Helper functions ########################################
-
+@profile
 def _normalize_counts(counts, val=1):
     """Normalizes a dictionary of counts, such as those returned by _get_frequencies().
 
@@ -269,7 +271,7 @@ def _normalize_counts(counts, val=1):
         frequencies[r] = val * float(counts[r]) / float(n)
     return frequencies
 
-
+@profile
 def _get_frequencies(data, col, col_vals, agg_col, agg_unit, agg_to_data):
     """Computes a frequencies dictionary for a given column and aggregation unit.
     
@@ -296,6 +298,7 @@ def _get_frequencies(data, col, col_vals, agg_col, agg_unit, agg_to_data):
             frequencies[name] = frequencies[name] + 1
     return frequencies, interesting_data
 
+@profile
 def _run_alg(data, agg_col, cat_cols, model, null_responses):
     """Runs an outlier detection algorithm, taking the model to use as input.
     
@@ -318,11 +321,15 @@ def _run_alg(data, agg_col, cat_cols, model, null_responses):
     outlier_scores = collections.defaultdict(dict)
     agg_to_data = {}
     agg_col_to_data = {}
-    for agg_unit in agg_units:
-        # TODO: could this be smarter and remove data each time? maybe no savings.
-        # TODO: support numpy only again
-        agg_to_data[agg_unit] = data[data[agg_col] == agg_unit]
-        agg_col_to_data[agg_unit] = {}
+    #If data is a df, use groupby for more efficient run
+    if isinstance(data, pd.DataFrame):
+        grouped_data = data.groupby(agg_col)
+        agg_to_data = {agg_unit: group for agg_unit, group in grouped_data}
+    else:
+        for agg_unit in agg_units:
+            agg_to_data[agg_unit] = data[data[agg_col] == agg_unit]
+    agg_col_to_data = {agg_unit:{} for agg_unit in agg_units}
+
         
     for col in cat_cols:
         col_vals = sorted(set(data[col]), key=lambda x: (str(type(x)), x))
@@ -343,6 +350,7 @@ def _run_alg(data, agg_col, cat_cols, model, null_responses):
 ########################################## Public functions ########################################
 
 if _STATS_AVAILABLE:
+    @profile
     def run_mma(data, aggregation_column, categorical_columns, null_responses=[]):
         """Runs the MMA algorithm (requires scipy module).
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scipy==1.9.3
 seaborn==0.11.1
 simple-settings==1.0.0
 datasets==2.14.6
-line-profiler==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ scikit-learn==1.3.1
 scipy==1.9.3
 seaborn==0.11.1
 simple-settings==1.0.0
+datasets==2.14.6
+line-profiler==4.1.1


### PR DESCRIPTION
Optimized the outlier detection algorithm code in a few places for faster runtime. To test impact of changes to runtime, we first implemented:

- Runtime benchmark method: A script that evaluates the runtime of the outlier detection algorithm on the open-source Adult Census Income benchmarking dataset from the UCI ML repository. The method uses the timeit library to time the outlier detection code run on the data set 4 times. The script then takes the minimum of 5 of those iterations.
- Added line profiler functionality: Added "@profile" decorators to several of the algo's methods and utilized the line_profiler package to retrieve a line-by-line breakdown of runtime in the Python code.

For each algorithm modification, we ran the benchmarking code to measure the runtime of the algorithm. We compared this to the runtime before the modification to validate runtime improvement. We also ran the unit tests to ensure the algorithm still functioned as expected.

To target the next modification, we then ran the profiler and found the section of the code that had the largest share of the total run time. Code improvements were made through a combination of manual changes and consulting gpt-4 for the most efficient ways to rewrite sections of code. After changes were made, we validated the changes by again running the line profiler and benchmarking script. This process was repeated until changes were no longer resulting in meaningful run time improvements. Profiler is run using the following commands in the terminal:
`kernprof -l benchmark_outlierdetect.py`
`python -m line_profiler -rmt "benchmark_outlierdetect.py.lprof"`

We documented each code change and subsequent run time improvements below. Please note that this is only the time to run the outlier detection algorithm (separate from loading and preprocessing data) and that run time relative to the changes is the value to consider:

- Original algorithm code: 4.63 sec
- Moved the frequency summation inside the [MultinomialModel.compute_outlier_scores outside the first for loop ](https://github.com/dimagi/outlier-detect/blob/05c67157d00fc0c3f0ab8f6d1f1ef8f7a68287c4/outlierdetect/outlierdetect.py#L120): 2.27 sec
- In _run_alg method, changed the first for loop, which calculates [agg_col_to_data to use the pandas groupby functionality ](https://github.com/dimagi/outlier-detect/blob/05c67157d00fc0c3f0ab8f6d1f1ef8f7a68287c4/outlierdetect/outlierdetect.py#L324)(instead of iterating with comparisons): 1.70 sec

For final benchmarking with an observation of how number of aggregation units (i.e. workers) and questions impacts performance run time, we get the following output by running `python3 benchmark_outlierdetect.py `:

Benchmarking outlier detection algorithm

Observing impact of aggregation unit scale
    Aggregation unit scale = 0.01, Execution time: 1.62 seconds
    Aggregation unit scale = 0.02, Execution time: 3.09 seconds
    Aggregation unit scale = 0.03, Execution time: 4.59 seconds

Observing impact of number of questions
    Number of questions = 1, Execution time: 0.59 seconds
    Number of questions = 2, Execution time: 1.11 seconds
    Number of questions = 3, Execution time: 1.61 seconds